### PR TITLE
Refactor mutable dictionary time bench, and add mutable dictionaries to space bench

### DIFF
--- a/Common.hs
+++ b/Common.hs
@@ -1,0 +1,26 @@
+module Common where
+
+import           Control.DeepSeq
+import qualified Data.HashTable.ST.Basic
+import qualified Data.HashTable.ST.Cuckoo
+import qualified Data.HashTable.ST.Linear
+import qualified Data.Judy
+
+
+instance NFData (Data.HashTable.ST.Basic.HashTable s k v) where
+  rnf x = seq x ()
+
+instance NFData (Data.HashTable.ST.Cuckoo.HashTable s k v) where
+  rnf x = seq x ()
+
+instance NFData (Data.HashTable.ST.Linear.HashTable s k v) where
+  rnf x = seq x ()
+
+instance NFData (Data.Judy.JudyL v) where
+  rnf x = seq x ()
+
+judyFromList :: [(Int,Int)] -> IO (Data.Judy.JudyL Int)
+judyFromList xs = do
+  j <- Data.Judy.new
+  mapM_ (\(k,v) -> Data.Judy.insert (fromIntegral k) v j) xs
+  return j

--- a/Space.hs
+++ b/Space.hs
@@ -5,11 +5,14 @@
 
 module Main where
 
+import           Common
 import           Control.DeepSeq
 import qualified Data.HashMap.Lazy
 import qualified Data.HashMap.Strict
+import qualified Data.HashTable.IO
 import qualified Data.IntMap.Lazy
 import qualified Data.IntMap.Strict
+import qualified Data.Judy
 import qualified Data.Map.Lazy
 import qualified Data.Map.Strict
 import           System.Random
@@ -46,3 +49,13 @@ fromlists =
      func "Data.IntMap.Lazy.fromList    (1 million)" Data.IntMap.Lazy.fromList elems
      func "Data.HashMap.Strict.fromList (1 million)" Data.HashMap.Strict.fromList elems
      func "Data.HashMap.Lazy.fromList   (1 million)" Data.HashMap.Lazy.fromList elems
+     io "Data.HashTable.IO.BasicHashTable (1 million)"
+          (Data.HashTable.IO.fromList :: [(Int,Int)] -> IO (Data.HashTable.IO.BasicHashTable Int Int))
+          elems
+     io "Data.HashTable.IO.CuckooHashTable (1 million)"
+          (Data.HashTable.IO.fromList :: [(Int,Int)] -> IO (Data.HashTable.IO.CuckooHashTable Int Int))
+          elems
+     io "Data.HashTable.IO.LinearHashTable (1 million)"
+          (Data.HashTable.IO.fromList :: [(Int,Int)] -> IO (Data.HashTable.IO.LinearHashTable Int Int))
+          elems
+     io "Data.Judy" judyFromList elems

--- a/Time.hs
+++ b/Time.hs
@@ -228,7 +228,7 @@ main = do
       , InsertInt title func <- funcs
       ]
     insertIntsIO funcs =
-      [ env (force <$> initial) (\ht -> bench (title ++ ":" ++ show i) $ nfIO (func ht i))
+      [ env initial (\ht -> bench (title ++ ":" ++ show i) $ nfIO (func ht i))
       | i <- [10, 100, 1000, 10000]
       , InsertIntIO title initial func <- funcs
       ]
@@ -339,18 +339,27 @@ insertIntMapStrict n0 = go n0 mempty
     go 0 acc = acc
     go n !acc = go (n - 1) (Data.IntMap.Strict.insert n n acc)
 
-insertHashTableIO :: Data.HashTable.Class.HashTable ht => Data.HashTable.IO.IOHashTable ht Int Int -> Int -> IO (Data.HashTable.IO.IOHashTable ht Int Int)
+insertHashTableIO :: Data.HashTable.Class.HashTable ht
+  => Data.HashTable.IO.IOHashTable ht Int Int
+  -> Int
+  -> IO (Data.HashTable.IO.IOHashTable ht Int Int)
 insertHashTableIO ht n0 = do
   mapM_ (\n -> Data.HashTable.IO.insert ht n n) [1..n0]
   return ht
 
-insertHashTableIOBasic :: Data.HashTable.IO.BasicHashTable Int Int -> Int -> IO (Data.HashTable.IO.BasicHashTable Int Int)
+insertHashTableIOBasic :: Data.HashTable.IO.BasicHashTable Int Int
+  -> Int
+  -> IO (Data.HashTable.IO.BasicHashTable Int Int)
 insertHashTableIOBasic = insertHashTableIO
 
-insertHashTableIOCuckoo :: Data.HashTable.IO.CuckooHashTable Int Int -> Int -> IO (Data.HashTable.IO.CuckooHashTable Int Int)
+insertHashTableIOCuckoo :: Data.HashTable.IO.CuckooHashTable Int Int
+  -> Int
+  -> IO (Data.HashTable.IO.CuckooHashTable Int Int)
 insertHashTableIOCuckoo = insertHashTableIO
 
-insertHashTableIOLinear :: Data.HashTable.IO.LinearHashTable Int Int -> Int -> IO (Data.HashTable.IO.LinearHashTable Int Int)
+insertHashTableIOLinear :: Data.HashTable.IO.LinearHashTable Int Int
+  -> Int
+  -> IO (Data.HashTable.IO.LinearHashTable Int Int)
 insertHashTableIOLinear = insertHashTableIO
 
 insertJudy :: Data.Judy.JudyL Int -> Int -> IO (Data.Judy.JudyL Int)
@@ -378,11 +387,14 @@ intersectionJudy ij0 ij1 = do
   mapM_ (\(k,v) -> Data.Judy.insert k v j) j1Kvs
   return j
 
-intersectionHashTableIO :: Data.HashTable.Class.HashTable ht => Data.HashTable.IO.IOHashTable ht Int Int -> Data.HashTable.IO.IOHashTable ht Int Int -> IO (Data.HashTable.IO.IOHashTable ht Int Int)
+intersectionHashTableIO :: Data.HashTable.Class.HashTable ht
+  => Data.HashTable.IO.IOHashTable ht Int Int
+  -> Data.HashTable.IO.IOHashTable ht Int Int
+  -> IO (Data.HashTable.IO.IOHashTable ht Int Int)
 intersectionHashTableIO ht0 ht1 = do
   ht <- Data.HashTable.IO.new
-  Data.HashTable.IO.mapM_ (\(k,v) -> Data.HashTable.IO.insert ht k v) ht0
-  Data.HashTable.IO.mapM_ (\(k,v) -> Data.HashTable.IO.insert ht k v) ht1
+  Data.HashTable.IO.mapM_ (uncurry (Data.HashTable.IO.insert ht)) ht0
+  Data.HashTable.IO.mapM_ (uncurry (Data.HashTable.IO.insert ht)) ht1
   return ht
 
 intersectionHashTableIOBasic :: Data.HashTable.IO.BasicHashTable Int Int

--- a/bench.cabal
+++ b/bench.cabal
@@ -12,6 +12,7 @@ test-suite space
   type: exitcode-stdio-1.0
   ghc-options: -O2
   main-is: Space.hs
+  other-modules: Common
   build-depends: base
                , weigh
                , deepseq
@@ -19,12 +20,15 @@ test-suite space
                , unordered-containers
                , bytestring-trie
                , random
+               , hashtables
+               , judy
 
 benchmark time
   default-language: Haskell2010
   type: exitcode-stdio-1.0
   ghc-options:       -Wall -O2 -rtsopts
   main-is:           Time.hs
+  other-modules: Common
   build-depends:     base
                    , bytestring
                    , ghc-prim


### PR DESCRIPTION
factored out some of the common code into a seperate module.

The results are as expected: 
Cuckoo and Linear are more space efficient than Basic, Judy is the most space efficient.

| Case | Bytes | GCs | Check |
|-|-|-|-|
| Data.Map.Strict.fromList     (1 million)      | 1,016,187,152 | 1,942 | OK |
| Data.Map.Lazy.fromList       (1 million)      | 1,016,187,152 | 1,942 | OK |
| Data.IntMap.Strict.fromList  (1 million)      |   776,852,648 | 1,489 | OK | 
| Data.IntMap.Lazy.fromList    (1 million)      |   776,852,648 | 1,489 | OK | 
| Data.HashMap.Strict.fromList (1 million)      |   161,155,384 |   314 | OK | 
| Data.HashMap.Lazy.fromList   (1 million)      |   161,155,384 |   314 | OK | 
| Data.HashTable.IO.BasicHashTable (1 million)  |   424,213,528 |   672 | OK | 
| Data.HashTable.IO.CuckooHashTable (1 million) |   173,580,920 |   244 | OK | 
| Data.HashTable.IO.LinearHashTable (1 million) |   201,294,784 |   389 | OK | 
| Data.Judy                                     |   112,000,400 |   214 | OK |
