### PR TITLE
Add basic Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,90 @@
+sudo: false
+language: c
+cache:
+  directories:
+  - "$HOME/.ghc"
+  - "$HOME/.cabal"
+  - "$HOME/.stack"
+matrix:
+  include:
+  - env: BUILD=stack ARGS="--resolver lts-6.20"
+    compiler: ": #stack 8.0.2"
+
+before_install:
+# Using compiler above sets CC to an invalid value, so unset it
+- unset CC
+
+# We want to always allow newer versions of packages when building on GHC HEAD
+- CABALARGS=""
+- if [ "x$GHCVER" = "xhead" ]; then CABALARGS=--allow-newer; fi
+
+# Download and unpack the stack executable
+- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
+- mkdir -p ~/.local/bin
+- |
+  if [ `uname` = "Darwin" ]
+  then
+    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+  else
+    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  fi
+
+  # Use the more reliable S3 mirror of Hackage
+  mkdir -p $HOME/.cabal
+  echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
+  echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
+
+  if [ "$CABALVER" != "1.16" ]
+  then
+    echo 'jobs: $ncpus' >> $HOME/.cabal/config
+  fi
+
+install:
+- echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+- if [ -f configure.ac ]; then autoreconf -i; fi
+- |
+  set -ex
+  case "$BUILD" in
+    stack)
+      stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+      ;;
+    cabal)
+      cabal --version
+      travis_retry cabal update
+
+      # Get the list of packages from the stack.yaml file
+      PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
+
+      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      ;;
+  esac
+  set +ex
+
+script:
+- |
+  set -ex
+  case "$BUILD" in
+    stack)
+      stack --no-terminal $ARGS test --bench --no-run-benchmarks
+      ;;
+    cabal)
+      cabal install --enable-tests $RUN_TESTS --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+
+      ORIGDIR=$(pwd)
+      for dir in $PACKAGES
+      do
+        cd $dir
+        cabal check || [ "$CABALVER" == "1.16" ]
+        cabal sdist
+        PKGVER=$(cabal info . | awk '{print $2;exit}')
+        SRC_TGZ=$PKGVER.tar.gz
+        cd dist
+        tar zxfv "$SRC_TGZ"
+        cd "$PKGVER"
+        cabal configure --enable-tests
+        cabal build
+        cd $ORIGDIR
+      done
+      ;;
+  esac
+  set +ex

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
       apt:
         packages:
         - libgmp-dev
+        - libjudydebian1
 
 before_install:
 # Using compiler above sets CC to an invalid value, so unset it

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 matrix:
   include:
   - env: BUILD=stack ARGS="--resolver lts-6.20"
-    compiler: ": #stack 8.0.2"
+    compiler: ": #stack 7.10.3"
 
 before_install:
 # Using compiler above sets CC to an invalid value, so unset it

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 matrix:
   include:
   - env: BUILD=stack ARGS="--resolver lts-6.20"
-    compiler: ": #stack 7.10.3
+    compiler: ": #stack 7.10.3"
     addons:
       apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     addons:
       apt:
         packages:
-        - libgmp-dev"
+        - libgmp-dev
 
 before_install:
 # Using compiler above sets CC to an invalid value, so unset it

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
         packages:
         - libgmp-dev
         - libjudydebian1
+        - libjudy-dev
 
 before_install:
 # Using compiler above sets CC to an invalid value, so unset it

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ cache:
 matrix:
   include:
   - env: BUILD=stack ARGS="--resolver lts-6.20"
-    compiler: ": #stack 7.10.3"
+    compiler: ": #stack 7.10.3
+    addons:
+      apt:
+        packages:
+        - libgmp-dev"
 
 before_install:
 # Using compiler above sets CC to an invalid value, so unset it


### PR DESCRIPTION
Have added Travis CI only for Stack support with the snapshot lts-6.20 (which is the repo's lts also).

@chrisdone I think you have to give travis the relevant permission for it to run.